### PR TITLE
Restrict token permissions

### DIFF
--- a/bin/authorize.js
+++ b/bin/authorize.js
@@ -15,7 +15,7 @@ ovh.request('POST', '/auth/credential', {
     { method: 'GET', path: '/domain/zone/*' },
     { method: 'POST', path: '/domain/zone/*' },
     { method: 'PUT', path: '/domain/zone/*' },
-    { method: 'DELETE', path: '/domain/zone/*/record' },
+    { method: 'DELETE', path: '/domain/zone/*/record/*' },
   ],
 }, (error, credential) => {
   console.log(error || credential);

--- a/bin/authorize.js
+++ b/bin/authorize.js
@@ -12,10 +12,10 @@ const ovh = require('ovh')({
 
 ovh.request('POST', '/auth/credential', {
   accessRules: [
-    { method: 'GET', path: '/*' },
-    { method: 'POST', path: '/*' },
-    { method: 'PUT', path: '/*' },
-    { method: 'DELETE', path: '/*' },
+    { method: 'GET', path: '/domain/zone/*' },
+    { method: 'POST', path: '/domain/zone/*' },
+    { method: 'PUT', path: '/domain/zone/*' },
+    { method: 'DELETE', path: '/domain/zone/*/record' },
   ],
 }, (error, credential) => {
   console.log(error || credential);


### PR DESCRIPTION
The token used by certbot does not need full OVH API access.
Access to the '/domain/' path is adequate to add the ACME challenge
data.