### PR TITLE
Add support for ACME challenges without subdomain

### DIFF
--- a/bin/create-record.js
+++ b/bin/create-record.js
@@ -15,6 +15,7 @@ const certbotValidation = process.env.CERTBOT_VALIDATION;
 const dom = parseDomain(certbotDomain);
 const domain = dom && dom.domain !== '' && dom.tld !== '' ? `${dom.domain}.${dom.tld}` : '';
 const subdomain = dom && dom.subdomain ? dom.subdomain : '';
+const record = dom.subdomain ? `_acme-challenge.${dom.subdomain}` : '_acme-challenge';
 
 const ovh = require('ovh')({
   endpoint: argv.endpoint || process.env.OVH_ENDPOINT || 'ovh-eu',
@@ -53,7 +54,7 @@ resolveDNS.then((servers) => {
   dns.setServers(servers);
   ovh.request('POST', `/domain/zone/${domain}/record`, {
     fieldType: 'TXT',
-    subDomain: `_acme-challenge.${subdomain}`,
+    subDomain: `${record}`,
     target: certbotValidation,
     ttl: 1,
   }, (recordErr) => {
@@ -69,7 +70,7 @@ resolveDNS.then((servers) => {
       }
 
       const timer = setInterval(() => {
-        dns.resolveTxt(`_acme-challenge.${subdomain}.${domain}`, (errResolve, records) => {
+        dns.resolveTxt(`${record}.${domain}`, (errResolve, records) => {
           if (records && records.length > 0) {
             clearInterval(timer);
             process.exit(0);

--- a/bin/delete-record.js
+++ b/bin/delete-record.js
@@ -10,6 +10,7 @@ require('dotenv').config({ path: env });
 const certbotDomain = process.env.CERTBOT_DOMAIN;
 
 const dom = parseDomain(certbotDomain);
+const record = dom.subdomain ? `_acme-challenge.${dom.subdomain}` : '_acme-challenge';
 
 const ovh = require('ovh')({
   endpoint: argv.endpoint || process.env.OVH_ENDPOINT || 'ovh-eu',
@@ -20,7 +21,7 @@ const ovh = require('ovh')({
 
 ovh.request('GET', `/domain/zone/${dom.domain}.${dom.tld}/record`, {
   fieldType: 'TXT',
-  subDomain: `_acme-challenge.${dom.subdomain}`,
+  subDomain: `${record}`,
 }, (recordErr, recordRes) => {
   if (recordErr) {
     console.error(recordErr);


### PR DESCRIPTION
Before this commit, the OVH API returned with an HTTP 400 (Bad Request)
error when an ACME challenge for a domain without subdomain should be
submitted. Deleting of these records was not possible.

This commit adds support for domains without subdomain.

Fixes: #5 